### PR TITLE
allow newer versions of nosexcover

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -38,3 +38,10 @@ coverage.xml
 
 # Superior text editors
 subl
+
+# Something better than just editors
+.idea/
+.ropeproject/
+
+# Git merge artifacts
+*.orig

--- a/README.md
+++ b/README.md
@@ -14,6 +14,7 @@ Example
 You'll find the [full example](./tests/workflow/example_1.py) in the tests/ directory.
 
 ```python
+    """
     This defines a workflow around the imperative: "Throw a Pie".
     
     In a simple system this is about 5 lines of code. But in others,
@@ -156,4 +157,5 @@ You'll find the [full example](./tests/workflow/example_1.py) in the tests/ dire
         # Ensure that our ThrowPieWorkflowC did not modify its components
         assert EmptyWorkflow.steps == []
         assert ThrowThingStep not in ThrowPieWorkflowC_A.steps
+    
 ```

--- a/README.md.in
+++ b/README.md.in
@@ -13,4 +13,6 @@ Example
 
 You'll find the [full example](./tests/workflow/example_1.py) in the tests/ directory.
 
+```python
     %(example_1.py)s
+```

--- a/marx/__init__.py
+++ b/marx/__init__.py
@@ -1,4 +1,3 @@
-
 # http://semver.org
 
-__version__ = '0.0.6'
+__version__ = '0.0.7'

--- a/setup.py
+++ b/setup.py
@@ -9,8 +9,10 @@ README = "README.md"
 base = os.path.dirname(__file__)
 local = lambda x: os.path.join(base, x)
 
+
 def read(fname):
     return open(local(fname)).read()
+
 
 def hydrate_examples():
     examples = {}
@@ -18,8 +20,7 @@ def hydrate_examples():
         if os.path.isdir(f):
             continue
         examples[os.path.basename(f)] = "\n    ".join(read(f).split("\n"))
-    #print examples.keys()
-    readme = read(README +".in") % examples
+    readme = read(README + ".in") % examples
     with open(local(README), "w") as f:
         f.write(readme)
 
@@ -35,11 +36,14 @@ setup(
     license="BSD",
     packages=find_packages(exclude=["tests.*", "tests"]),
     long_description=read(README),
-    setup_requires=['nose>=1.0', 'coverage==3.6', 'nosexcover', 'mock'],
+    setup_requires=[
+        'nose>=1.0',
+        'coverage>=3.6',
+        'nosexcover',
+        'mock'
+    ],
     test_suite='nose.collector',
     classifiers=[
         "License :: OSI Approved :: BSD License",
     ],
 )
-
-


### PR DESCRIPTION
Was getting version conflicts when setting up mac; the fix turned out to be changing "nosexcover==3.6" to "nosexcover>=3.6". The tests pass OK with v3.7.1 of that package.